### PR TITLE
Change API URL

### DIFF
--- a/libraries/api.js
+++ b/libraries/api.js
@@ -1,5 +1,5 @@
 var API = {
-  url: 'https://pull-requests-api.herokuapp.com/pull_requests',
+  url: 'https://pull-requests.colabs.dev',
 
   reload: function(callback) {
     var authors = LocalStorage.read('authors'),


### PR DESCRIPTION
Because Heroku is no longer free, the API was moved to another host and its URL has changed. Since the URL is hardcoded, we need to update the code to point to the correct URL.

Ideally, the API URL should be read from env vars, but this will be done in future PRs.