### PR TITLE
Fix API url

### DIFF
--- a/libraries/api.js
+++ b/libraries/api.js
@@ -1,5 +1,5 @@
 var API = {
-  url: 'https://pull-requests.colabs.dev',
+  url: 'https://pull-requests.colabs.dev/pull_requests',
 
   reload: function(callback) {
     var authors = LocalStorage.read('authors'),


### PR DESCRIPTION
In the [last PR](https://github.com/arturcp/pull-requests-plugin/pull/2) we changed the API URL, but we forgot to add the `/pull_requests` uri. This PR fixes that.